### PR TITLE
Update Dir.glob to support running outside ios directory

### DIFF
--- a/docs/getting-started/react-native-ios.mdx
+++ b/docs/getting-started/react-native-ios.mdx
@@ -28,7 +28,7 @@ end
 
 # Post Install processing for Flipper
 def flipper_post_install(installer)
-  file_name = Dir.glob("*.xcodeproj")[0]
+  file_name = Dir.glob("#{__dir__}/*.xcodeproj")[0]
   app_project = Xcodeproj::Project.open(file_name)
   app_project.native_targets.each do |target|
     target.build_configurations.each do |config|


### PR DESCRIPTION

## Summary
The suggested code for `Podfile` does not work if you run the command from anywhere other than the `ios` directory where it is located. Cocoapods supports the `--project-directory=path/to/ios` command line argument which will fail without explicitly looking for `*.xcodeproj` files within the same directory as `Podfile`.

I ran into this as my workflow is to run `pod install --project-directory=./ios` from the root of the project. The error message is not particularly obvious as there's no error checking of `file_name`.

```
[!] An error occurred while processing the post-install hook of the Podfile.

no implicit conversion of nil into String
… stack trace 
```

## Changelog

- Updated documentation to support `--project-directory` runs of `pod install`

## Test Plan

- In a test project, run `cd ios ; pod install; cd -` and `pod install --project-directory=./ios` with the suggest changes to the Podfile.